### PR TITLE
Accordion 컴포넌트 스토리 작성

### DIFF
--- a/src/components/Accordion/Accordion.stories.tsx
+++ b/src/components/Accordion/Accordion.stories.tsx
@@ -1,0 +1,57 @@
+import { Meta, StoryObj } from "@storybook/react";
+
+import Accordion, { type AccordionProps } from "./Accordion";
+import { type AccordionSummaryProps } from "./AccordionSummary";
+
+type AccordionCompositionProps = Pick<AccordionProps, "width" | "open"> &
+  Pick<AccordionSummaryProps, "color" | "size">;
+
+const meta: Meta = {
+  component: Accordion,
+  tags: ["autodocs"],
+  argTypes: {
+    children: {
+      table: { disable: true },
+    },
+    color: {
+      control: "inline-radio",
+      options: ["black", "grey"],
+      description: "Accordion.Summary의 글씨 색상을 결정합니다.",
+      table: {
+        defaultValue: { summary: "black" },
+        category: "Accordion.Summary",
+      },
+    },
+    size: {
+      control: "inline-radio",
+      options: ["sm", "md"],
+      description: "Accordion.Summary의 크기를 결정합니다.",
+      table: {
+        defaultValue: { summary: "md" },
+        category: "Accordion.Summary",
+      },
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<AccordionCompositionProps>;
+
+export const Variants: Story = {
+  args: {
+    width: "200px",
+    open: false,
+    color: "black",
+    size: "md",
+  },
+  render: ({ width, open, color, size }) => (
+    <Accordion width={width} open={open}>
+      <Accordion.Details>
+        <Accordion.Summary color={color} size={size}>
+          Summary
+        </Accordion.Summary>
+        Details
+      </Accordion.Details>
+    </Accordion>
+  ),
+};

--- a/src/components/Accordion/Accordion.tsx
+++ b/src/components/Accordion/Accordion.tsx
@@ -10,7 +10,7 @@ interface AccordionProps {
   children: ReactNode;
 }
 
-export default function Accordion({
+function Accordion({
   width = 200,
   open: initOpen = false,
   children,
@@ -24,3 +24,5 @@ export default function Accordion({
 
 Accordion.Details = AccordionDetails;
 Accordion.Summary = AccordionSummary;
+
+export default Accordion;

--- a/src/components/Accordion/Accordion.tsx
+++ b/src/components/Accordion/Accordion.tsx
@@ -4,7 +4,7 @@ import { AccordionContextProvider } from "./AccordionContextProvider";
 import AccordionDetails from "./AccordionDetails";
 import AccordionSummary from "./AccordionSummary";
 
-interface AccordionProps {
+export interface AccordionProps {
   width?: number | string;
   open?: boolean;
   children: ReactNode;

--- a/src/components/Accordion/Accordion.tsx
+++ b/src/components/Accordion/Accordion.tsx
@@ -5,11 +5,20 @@ import AccordionDetails from "./AccordionDetails";
 import AccordionSummary from "./AccordionSummary";
 
 export interface AccordionProps {
+  /**
+   * Accordion의 너비를 결정합니다.
+   * @default 200
+   */
   width?: number | string;
+  /**
+   * Accordion의 초기 열림 상태를 결정합니다.
+   * @default false
+   */
   open?: boolean;
   children: ReactNode;
 }
 
+/** Accordion은 세부 내용을 숨기거나 보여줄 수 있는 컴포넌트입니다. */
 function Accordion({
   width = 200,
   open: initOpen = false,

--- a/src/components/Accordion/AccordionSummary.tsx
+++ b/src/components/Accordion/AccordionSummary.tsx
@@ -9,7 +9,7 @@ import {
 } from "./AccordionContextProvider";
 import ChevronIcon from "./ChevronIcon/ChevronIcon";
 
-interface AccordionSummaryProps {
+export interface AccordionSummaryProps {
   color?: "black" | "grey";
   size?: "md" | "sm";
   children: ReactNode | RenderComponentType;

--- a/src/components/Accordion/AccordionSummary.tsx
+++ b/src/components/Accordion/AccordionSummary.tsx
@@ -7,7 +7,7 @@ import {
   type AccordionContextType,
   useAccordion,
 } from "./AccordionContextProvider";
-import ChevronIcon from "./ChevronIcon/ChevronIcon";
+import ChevronIcon from "./ChevronIcon";
 
 export interface AccordionSummaryProps {
   color?: "black" | "grey";


### PR DESCRIPTION
closed #11 

## ✅ 작업 내용
- Accordion 컴포넌트 스토리 작성
- Accordion 컴포넌트 문서화

## 📌 이슈 사항
- Accordion이 Accordion.Details, Accordion.Summary를 조합해서 사용하다보니 스토리를 작성하는게 조금 번거롭습니다.
  - autodocs 기능을 사용하면 Accordion 컴포넌트에 대한 메타 데이터만 문서화되서 Accordion.Summary 컴포넌트 props에 대한 설명을 일일이 작성해야 합니다. 
  - Accordion / Accordion.Summary props에 대한 설명을 구분하기 위해 [`table.category`](https://storybook.js.org/docs/api/arg-types#tablecategory) 속성을 이용했습니다.
    <img width="1036" alt="image" src="https://github.com/git-challenge-design-system/design-system/assets/96400112/52cb9357-3cee-4b71-bb3c-c5d19033effb">

## ✍ 궁금한 점
- 스토리랑 props 설명이 충분한지 궁금합니다!

cf. [[Storybook] 스토리북의 Docs 기능으로 컴포넌트 라이브러리 문서화하기](https://iyu88.github.io//storybook/2023/04/07/storybook-docs.html) 스토리북 설명이 잘 되어있어서 공유합니당