### PR TITLE
IconButton 컴포넌트 스토리 작성

### DIFF
--- a/src/components/IconButton/IconButton.stories.tsx
+++ b/src/components/IconButton/IconButton.stories.tsx
@@ -1,0 +1,34 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import {
+  IoCloseOutline,
+  IoEllipsisHorizontal,
+  IoInformation,
+} from "react-icons/io5";
+
+import IconButton from ".";
+
+const meta: Meta<typeof IconButton> = {
+  component: IconButton,
+  tags: ["autodocs"],
+  argTypes: {
+    children: {
+      control: "inline-radio",
+      options: ["close", "ellipsis", "information"],
+      mapping: {
+        close: <IoCloseOutline />,
+        ellipsis: <IoEllipsisHorizontal />,
+        information: <IoInformation />,
+      },
+    },
+    onClick: { action: "clicked" },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof IconButton>;
+
+export const Basic: Story = {
+  args: {
+    children: "close",
+  },
+};

--- a/src/components/IconButton/IconButton.tsx
+++ b/src/components/IconButton/IconButton.tsx
@@ -6,10 +6,13 @@ import * as styles from "./IconButton.css";
 
 export interface IconButtonProps
   extends Pick<ButtonHTMLAttributes<HTMLButtonElement>, "onClick"> {
+  /** IconButton의 className을 설정합니다. className을 통해 스타일을 확장할 수 있습니다. */
   className?: string;
+  /** IconButton안에 들어갈 아이콘 컴포넌트입니다. */
   children: ReactNode;
 }
 
+/** IconButton는 아이콘만 존재하는 버튼 컴포넌트입니다. */
 export default function IconButton({
   className = "",
   children,


### PR DESCRIPTION
closed #13

## ✅ 작업 내용
- IconButton 컴포넌트 스토리 작성 및 문서화

## 📌 이슈 사항
- 없습니다

## ✍ 궁금한 점
- 스토리에서 `children`으로 리액트 컴포넌트를 설정하는게 불가능해서 아래 그림처럼 컨트롤 옵션으로 3개의 아이콘 컴포넌트 설정했습니다. 근데 스토리만 보면 `children` 값을 3개 중 하나로 받는 걸로 오해할 거 같은데 어떻게 생각하시나요?
<img width="708" alt="image" src="https://github.com/git-challenge-design-system/design-system/assets/96400112/8ef6a45f-12d8-4115-8d2d-10d1676057cb">

